### PR TITLE
fix: add debounce on estimateSwap

### DIFF
--- a/web/hooks/useSwapEstimate.ts
+++ b/web/hooks/useSwapEstimate.ts
@@ -97,7 +97,14 @@ export function useSwapEstimate(
       }
     };
 
-    estimateSwap();
+    // debounce 2 second delay
+    const debouncedEstimateSwap = setTimeout(() => {
+      estimateSwap();
+    }, 2000);
+
+    return () => {
+      clearTimeout(debouncedEstimateSwap);
+    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [sourceToken, destToken, sourceAmount, connection, provider]);
 


### PR DESCRIPTION
Currently `estimateSwap` runs on every value change, which ends up DoSing the RPC provider and causing 429 status "Too Many Requests". Debounce reduces this problem, but further mitigation is still required. This is because the context hook itself is likely being re-created unnecessarily which in turn still creates more calls.