### PR TITLE
fix: add debounce on balance rpc calls

### DIFF
--- a/web/hooks/useTokenBalance.ts
+++ b/web/hooks/useTokenBalance.ts
@@ -88,7 +88,13 @@ export function useTokenBalance(
       }
     }
 
-    fetchBalance();
+    const debouncedFetchBalance = setTimeout(() => {
+      fetchBalance();
+    }, 2000);
+
+    return () => {
+      clearTimeout(debouncedFetchBalance);
+    };
   }, [walletAddress, tokenAddress, cluster.endpoint]);
 
   return { balance, loading, error };


### PR DESCRIPTION
Similar problem as `estimateSwap` add debounce on balance calls due to too many calls. This is a temporary fix, later the balances can be cached and refetched only post-action and/or on regular intervals (something like ~1min.)