### PR TITLE
refactor: allow only devnet in production [DAR-30]

### DIFF
--- a/web/components/cluster/cluster-data-access.tsx
+++ b/web/components/cluster/cluster-data-access.tsx
@@ -46,9 +46,13 @@ const clusterAtom = atomWithStorage<Cluster>(
   'solana-cluster',
   defaultClusters[0],
 );
+
 const clustersAtom = atomWithStorage<Cluster[]>(
   'solana-clusters',
-  defaultClusters,
+  // in production only allow devnet
+  process.env.NODE_ENV === 'production'
+    ? [defaultClusters[0]]
+    : defaultClusters,
 );
 
 const activeClustersAtom = atom<Cluster[]>((get) => {


### PR DESCRIPTION
Production allows selecting testnet or local even though we don't have ready deployments there. Disable for now.