### PR TITLE
fix: disable google translations for now due to errors

### DIFF
--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -19,7 +19,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang="en">
+    <html lang="en" className="notranslate" translate='no'>
       <head>
         <link
           rel="stylesheet"


### PR DESCRIPTION
Google translations break wallet integration - disable for now for to avoid them.