### PR TITLE
Add CheckMevAttackWrapper to loading state of mev results

### DIFF
--- a/apps/web/src/components/MevAttackResults/CheckMevAttackWrapper.tsx
+++ b/apps/web/src/components/MevAttackResults/CheckMevAttackWrapper.tsx
@@ -1,12 +1,14 @@
 "use client";
 
 import { cn } from "@/utils/common";
-import { useRef, useEffect } from "react";
+import { useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 
 function BackgroundRevealElement() {
+  const [isMounted, setIsMounted] = useState(false);
   const element = useRef<HTMLDivElement | null>(null);
   useEffect(() => {
+    setIsMounted(true);
     function handler(e: MouseEvent) {
       if (element.current) {
         const x = e.clientX,
@@ -27,14 +29,13 @@ function BackgroundRevealElement() {
     "bg-[url(/images/bg-masked.png)] mouse-tracker fixed w-screen",
     "h-screen z-10 top-0 left-0 opacity-90 bg-cover bg-no-repeat bg-fixed invisible",
   );
-  if (typeof document === "object") {
-    return createPortal(
-      <>
-        <div className={className} ref={element} />
-      </>,
-      document.body,
-    );
-  }
+  return isMounted ? createPortal(
+    <>
+      <div className={className} ref={element} />
+    </>,
+    document.body,
+  ) : null;
+
 }
 
 const className = cn(
@@ -42,7 +43,7 @@ const className = cn(
   "bg-no-repeat bg-fixed relative top-0 left-0 bg-brand-80 text-brand-20",
 );
 
-export default function RootLayout({
+export default function CheckMevAttackWrapper({
   children,
 }: Readonly<{
   children: React.ReactNode;

--- a/apps/web/src/components/MevAttackResults/CheckMevAttackWrapper.tsx
+++ b/apps/web/src/components/MevAttackResults/CheckMevAttackWrapper.tsx
@@ -29,13 +29,14 @@ function BackgroundRevealElement() {
     "bg-[url(/images/bg-masked.png)] mouse-tracker fixed w-screen",
     "h-screen z-10 top-0 left-0 opacity-90 bg-cover bg-no-repeat bg-fixed invisible",
   );
-  return isMounted ? createPortal(
-    <>
-      <div className={className} ref={element} />
-    </>,
-    document.body,
-  ) : null;
-
+  return isMounted
+    ? createPortal(
+        <>
+          <div className={className} ref={element} />
+        </>,
+        document.body,
+      )
+    : null;
 }
 
 const className = cn(

--- a/apps/web/src/components/MevAttackResults/index.tsx
+++ b/apps/web/src/components/MevAttackResults/index.tsx
@@ -1,22 +1,21 @@
+import CheckMevAttackWrapper from "@/components/MevAttackResults/CheckMevAttackWrapper";
 import TotalExtracted from "@/components/MevAttackResults/TotalExtracted";
 import WaddlesWithMessage from "@/components/MevAttackResults/WaddlesWithMessage";
-import DetailResults from "./DetailResults";
 import useGetTotalExtracted from "@/hooks/api/useGetTotalExtracted";
-import { useMemo } from "react";
 import NoTransactionWaddle from "./NoTransactionWaddle";
+import Image from "next/image";
+import DetailResults from "./DetailResults";
 
 export default function MevAttackResults({ address }: { address: string }) {
   const { data } = useGetTotalExtracted(address);
 
-  const accountHasNoTransactions = useMemo(() => {
-    return data?.processingBlocks.total === 0;
-  }, [data]);
+  const accountHasNoTransactions = data?.processingBlocks.total === 0;
 
   if (accountHasNoTransactions) {
     return <NoTransactionWaddle />;
   }
 
-  return (
+  return data ? (
     <div className="relative">
       <div className="lg:flex flex-row space-between items-center relative lg:pb-20 max-sm:mb-20">
         <div className="lg:w-[400px] max-lg:mb-20">
@@ -33,5 +32,21 @@ export default function MevAttackResults({ address }: { address: string }) {
         <DetailResults address={address} />
       </div>
     </div>
+  ) : (
+    <CheckMevAttackWrapper>
+      {" "}
+      <div className="flex items-center justify-between select-none">
+        <div className="flex-1">
+          <h1 className="font-primary text-3xl leading-7 text-brand-30 mb-8">
+            Analyzing The Blocks
+            <br />
+            <span className="text-brand-20">This might take a few seconds.</span>
+          </h1>
+        </div>
+        <div className="flex items-center justify-end flex-1">
+          <Image src="/images/waddles/pose6.png" alt="Waddles" width={350} height={477} />
+        </div>
+      </div>
+    </CheckMevAttackWrapper>
   );
 }

--- a/apps/web/src/components/MevAttackResults/index.tsx
+++ b/apps/web/src/components/MevAttackResults/index.tsx
@@ -8,7 +8,7 @@ import DetailResults from "./DetailResults";
 
 import { useState } from "react";
 export default function MevAttackResults({ address }: { address: string }) {
-  const { data, isLoading } = useGetTotalExtracted(address);
+  const { data } = useGetTotalExtracted(address);
   const [showLoadingScreen, setShowLoadingScreen] = useState(true);
 
   const accountHasNoTransactions = data?.processingBlocks.total === 0;
@@ -17,7 +17,11 @@ export default function MevAttackResults({ address }: { address: string }) {
     return <NoTransactionWaddle />;
   }
 
-  if (!isLoading) {
+  if (
+    data?.processingBlocks?.total &&
+    data?.processingBlocks?.total > 0 &&
+    data?.processingBlocks?.total === data?.processingBlocks?.completed
+  ) {
     setTimeout(() => {
       setShowLoadingScreen(false);
     }, 2000);

--- a/apps/web/src/components/MevAttackResults/index.tsx
+++ b/apps/web/src/components/MevAttackResults/index.tsx
@@ -6,8 +6,10 @@ import NoTransactionWaddle from "./NoTransactionWaddle";
 import Image from "next/image";
 import DetailResults from "./DetailResults";
 
+import { useState } from "react";
 export default function MevAttackResults({ address }: { address: string }) {
-  const { data } = useGetTotalExtracted(address);
+  const { data, isLoading } = useGetTotalExtracted(address);
+  const [showLoadingScreen, setShowLoadingScreen] = useState(true);
 
   const accountHasNoTransactions = data?.processingBlocks.total === 0;
 
@@ -15,7 +17,28 @@ export default function MevAttackResults({ address }: { address: string }) {
     return <NoTransactionWaddle />;
   }
 
-  return data ? (
+  if (!isLoading) {
+    setTimeout(() => {
+      setShowLoadingScreen(false);
+    }, 2000);
+  }
+
+  return showLoadingScreen ? (
+    <CheckMevAttackWrapper>
+      <div className="flex items-center justify-between select-none">
+        <div className="flex-1">
+          <h1 className="font-primary text-3xl leading-7 text-brand-30 mb-8">
+            Analyzing The Blocks
+            <br />
+            <span className="text-brand-20">This might take a few seconds.</span>
+          </h1>
+        </div>
+        <div className="flex items-center justify-end flex-1">
+          <Image src="/images/waddles/pose6.png" alt="Waddles" width={350} height={477} />
+        </div>
+      </div>
+    </CheckMevAttackWrapper>
+  ) : (
     <div className="relative">
       <div className="lg:flex flex-row space-between items-center relative lg:pb-20 max-sm:mb-20">
         <div className="lg:w-[400px] max-lg:mb-20">
@@ -32,21 +55,5 @@ export default function MevAttackResults({ address }: { address: string }) {
         <DetailResults address={address} />
       </div>
     </div>
-  ) : (
-    <CheckMevAttackWrapper>
-      {" "}
-      <div className="flex items-center justify-between select-none">
-        <div className="flex-1">
-          <h1 className="font-primary text-3xl leading-7 text-brand-30 mb-8">
-            Analyzing The Blocks
-            <br />
-            <span className="text-brand-20">This might take a few seconds.</span>
-          </h1>
-        </div>
-        <div className="flex items-center justify-end flex-1">
-          <Image src="/images/waddles/pose6.png" alt="Waddles" width={350} height={477} />
-        </div>
-      </div>
-    </CheckMevAttackWrapper>
   );
 }


### PR DESCRIPTION
### Description

When isLoading from getting MEV checker results is false, shows the loading spotlight screen, waits 2 seconds then shows the results

https://github.com/user-attachments/assets/1088c25e-0a45-4399-ae49-7db1968a2ff5


### Developer checklist:

<!--
Before requesting for code review, please ensure that the following tasks
are completed. Otherwise, keep the PR drafted.
-->

- [ yes ] Read your code changes at least once
- [ ja ] Types checked, lint and formatting is correct, unit/integration tests not failing
- [ oui ] No console errors on web
